### PR TITLE
Add support for dynamically loaded content

### DIFF
--- a/jquery.easyModal.js
+++ b/jquery.easyModal.js
@@ -91,7 +91,7 @@
 				});
 
 				// Close when button pressed
-				$modal.find(o.closeButtonClass).click(function(e) {
+				$modal.on('click', o.closeButtonClass, function(e) {
 					$modal.trigger('closeModal');
 					e.preventDefault();
 				});


### PR DESCRIPTION
I tried using the plugin for showing modals with content loaded through ajax calls and faced two problems:
1. The modal was not correctly positioned when open, in cases where the loaded content changed the container's dimensions;
2. and buttons with `closeButtonClass` were not firing the `closeModal` event when added after the call to `easyModal`.

I fixed both problems, although, there might be some drawbacks:

The fIx for the first problem requires the position to be calculated every time the modal is open, which might be bad for performance. I don't think the difference is noticeable, though.

The fix for the second problem requires at least jQuery version 1.7 because it uses the `on` function. I was not able find the minimum required version anywhere, so let me know if version 1.7 is unacceptable.

I would love to hear your opinions.

Thank you.
