### PR TITLE
Fix apply error on <IE9

### DIFF
--- a/jquery.easyModal.js
+++ b/jquery.easyModal.js
@@ -25,13 +25,13 @@
                 onOpen: false,
                 onClose: false,
                 zIndex: function () {
-                    return 1 + Math.max.apply(Math, $('*').map(function () {
+                    return 1 + Math.max.apply(Math, $.makeArray($('*').map(function () {
                         return $(this).css('z-index');
                     }).filter(function () {
                         return $.isNumeric(this);
                     }).map(function () {
                         return parseInt(this, 10);
-                    }));
+                    })));
                 },
                 updateZIndexOnOpen: true
             };


### PR DESCRIPTION
Resolves the "Function.prototype.apply: Array or arguments object expected" error seen in IE7/8.
