### PR TITLE
Remove old overlays

### DIFF
--- a/jquery.easyModal.js
+++ b/jquery.easyModal.js
@@ -40,6 +40,8 @@
 
             return this.each(function () {
 
+                $(o.overlayParent).find('.lean-overlay').remove();
+
                 var o = options,
                     $overlay = $('<div class="lean-overlay"></div>'),
                     $modal = $(this);


### PR DESCRIPTION
Now old overlays are not removed because of what each opening a modal window background becomes darker.
