### PR TITLE
Fix semver version for bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,6 @@
     "tests"
   ],
   "dependencies": {
-    "jQuery": ">=.7.0"
+    "jQuery": ">=1.7.0"
   }
 }


### PR DESCRIPTION
By semver (which bower uses) documentation http://semver.org/spec/v2.0.0.html 

With current version I get this error:

```
bower ENORESTARGET  Tag/branch >=.7.0 does not exist
```
