### PR TITLE
Add CSS3 transition (optional)

### DIFF
--- a/jquery.easyModal.js
+++ b/jquery.easyModal.js
@@ -76,6 +76,7 @@
                 $modal.bind('openModal', function () {
                     var overlayZ = o.updateZIndexOnOpen ? o.zIndex() : parseInt($overlay.css('z-index'), 10),
                         modalZ = overlayZ + 1;
+
                     if(o.transitionIn !== '' && o.transitionOut !== ''){
                         $modal.removeClass(o.transitionOut).addClass(o.transitionIn);
                     };


### PR DESCRIPTION
Hi there,

As I wanted to add some transitions for the opening & closing events, I decided to edit the plugin itself. I'm far from being a jQuery expert, so please review my code before merging the pull request.

In my case, I used https://github.com/daneden/animate.css to animate my modals:

``` javascript
$('.ta-modal').easyModal({
    top: 200,
    overlay: 0.2,
    transitionIn: 'animated bounceIn',
    transitionOut: 'animated bounceOut'
});
```

Lemme know what you think!
