### PR TITLE
update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,6 @@
     "tests"
   ],
   "dependencies": {
-    "jQuery": ">=1.7.0"
+    "jquery": ">=1.7.0"
   }
 }


### PR DESCRIPTION
For some reason, during bower install, if you list jQuery as a dependency, it will generate a broken .bower.json file. If you use lowercase q it will work just fine.